### PR TITLE
Avoid crashes on comments before the first move.

### DIFF
--- a/ataxx/pgn.py
+++ b/ataxx/pgn.py
@@ -48,10 +48,11 @@ def parse_moves(board, parent, q):
                 word = q.get()
                 if word == "}":
                     break
-                if last_node.comment == None:
-                    last_node.comment = word
-                else:
-                    last_node.comment += " " + word
+                if last_node:
+                    if last_node.comment == None:
+                        last_node.comment = word
+                    else:
+                        last_node.comment += " " + word
         # An alternate line just started
         elif word == "(":
             nboard = copy.deepcopy(board)


### PR DESCRIPTION
Example PGN:

[Event "?"]
[White "Lelax IV"]
[Black "Autaxx"]
[FEN "3x2o/7/7/7/2o4/7/6x o 3 2"]
[Adjudicated "Engine crashed"]
[Result "1-0"]

 { engine crashed } 1-0