### PR TITLE
Make Move hashable.

### DIFF
--- a/ataxx/__init__.py
+++ b/ataxx/__init__.py
@@ -79,6 +79,9 @@ class Move:
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash((self.fr_x, self.fr_y, self.to_x, self.to_y))
+
     def __str__(self):
         # Null move
         if self == Move.null():


### PR DESCRIPTION
Because we custom-define ```__eq__```, Move is no longer hashable
unless we define our own hashing function.